### PR TITLE
glscopeclient: Fix up shader syntax to avoid embedded struct definitions

### DIFF
--- a/glscopeclient/shaders/waveform-compute.glsl
+++ b/glscopeclient/shaders/waveform-compute.glsl
@@ -4,13 +4,15 @@
 layout(binding=0, rgba32f) uniform image2D outputTex;
 
 //Voltage data
+struct data_point
+{
+	float x;		//x pixel position (fractional)
+	float voltage;	//y value of this sample, in pixels
+};
+
 layout(std430, binding=1) buffer waveform
 {
-	struct
-	{
-		float x;		//x pixel position (fractional)
-		float voltage;	//y value of this sample, in pixels
-	} data[];
+	data_point data[];
 };
 
 //Global configuration for the run


### PR DESCRIPTION
This is a fix for the error :

ERROR: Compile of shader shaders/waveform-compute.glsl failed:
 0:13(4): error: embedded structure declarations are not allowed

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>