### PR TITLE
Basic preference system infrastructure

### DIFF
--- a/glscopeclient/CMakeLists.txt
+++ b/glscopeclient/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(glscopeclient
 	OscilloscopeWindow.cpp
 	Program.cpp
 	Preference.cpp
+	PreferenceManager.cpp
 	ProtocolAnalyzerWindow.cpp
 	ProtocolDecoderDialog.cpp
 	ScopeApp.cpp

--- a/glscopeclient/CMakeLists.txt
+++ b/glscopeclient/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(glscopeclient
 	InstrumentConnectionDialog.cpp
 	OscilloscopeWindow.cpp
 	Program.cpp
+	Preference.cpp
 	ProtocolAnalyzerWindow.cpp
 	ProtocolDecoderDialog.cpp
 	ScopeApp.cpp

--- a/glscopeclient/OscilloscopeWindow.cpp
+++ b/glscopeclient/OscilloscopeWindow.cpp
@@ -397,6 +397,7 @@ bool OscilloscopeWindow::OnTimer(int /*timer*/)
 bool OscilloscopeWindow::on_delete_event(GdkEventAny* /*any_event*/)
 {
 	CloseSession();
+	m_preferences.SavePreferences();
 	return false;
 }
 

--- a/glscopeclient/OscilloscopeWindow.cpp
+++ b/glscopeclient/OscilloscopeWindow.cpp
@@ -397,7 +397,6 @@ bool OscilloscopeWindow::OnTimer(int /*timer*/)
 bool OscilloscopeWindow::on_delete_event(GdkEventAny* /*any_event*/)
 {
 	CloseSession();
-	m_preferences.SavePreferences();
 	return false;
 }
 
@@ -406,6 +405,9 @@ bool OscilloscopeWindow::on_delete_event(GdkEventAny* /*any_event*/)
  */
 void OscilloscopeWindow::CloseSession()
 {
+    //Save preferences
+    m_preferences.SavePreferences();
+
 	//Close all of our UI elements
 	for(auto it : m_historyWindows)
 		delete it.second;

--- a/glscopeclient/OscilloscopeWindow.h
+++ b/glscopeclient/OscilloscopeWindow.h
@@ -42,6 +42,7 @@
 #include "ProtocolAnalyzerWindow.h"
 #include "HistoryWindow.h"
 #include "ScopeSyncWizard.h"
+#include "PreferenceManager.h"
 
 /**
 	@brief Main application window class for an oscilloscope
@@ -177,6 +178,9 @@ protected:
 
 	//shared by all scopes/channels
 	std::map<Oscilloscope*, HistoryWindow*> m_historyWindows;
+	
+	//Preferences state
+	PreferenceManager m_preferences;
 
 public:
 	//All of the waveform groups and areas, regardless of where they live

--- a/glscopeclient/Preference.cpp
+++ b/glscopeclient/Preference.cpp
@@ -37,41 +37,41 @@
 
 #include "Preference.h"
 
-const std::string& Preference::get_identifier() const
+const std::string& Preference::GetIdentifier() const
 {
     return m_identifier;
 }
 
-const std::string& Preference::get_description() const
+const std::string& Preference::GetDescription() const
 {
     return m_description;
 }
 
-PreferenceType Preference::get_type() const
+PreferenceType Preference::GetType() const
 {
     return m_type;
 }
 
-bool Preference::get_bool() const
+bool Preference::GetBool() const
 {
     if(m_type != PreferenceType::Boolean)
         throw std::runtime_error("Preference type mismatch");
 
-    return get_value_raw<bool>();
+    return GetValueRaw<bool>();
 }
 
-double Preference::get_real() const
+double Preference::GetReal() const
 {
     if(m_type != PreferenceType::Real)
         throw std::runtime_error("Preference type mismatch");
 
-    return get_value_raw<double>();
+    return GetValueRaw<double>();
 }
 
-const std::string& Preference::get_string() const
+const std::string& Preference::GetString() const
 {
     if(m_type != PreferenceType::String)
         throw std::runtime_error("Preference type mismatch");
 
-    return get_value_raw<std::string>();
+    return GetValueRaw<std::string>();
 }

--- a/glscopeclient/Preference.cpp
+++ b/glscopeclient/Preference.cpp
@@ -2,7 +2,7 @@
 *                                                                                                                      *
 * ANTIKERNEL v0.1                                                                                                      *
 *                                                                                                                      *
-* Copyright (c) 2012-2018 Andrew D. Zonenberg                                                                          *
+* Copyright (c) 2012-2020 Andrew D. Zonenberg                                                                          *
 * All rights reserved.                                                                                                 *
 *                                                                                                                      *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
@@ -37,12 +37,14 @@
 
 #include "Preference.h"
 
-const std::string& Preference::GetIdentifier() const
+using namespace std;
+
+const string& Preference::GetIdentifier() const
 {
     return m_identifier;
 }
 
-const std::string& Preference::GetDescription() const
+const string& Preference::GetDescription() const
 {
     return m_description;
 }
@@ -55,7 +57,7 @@ PreferenceType Preference::GetType() const
 bool Preference::GetBool() const
 {
     if(m_type != PreferenceType::Boolean)
-        throw std::runtime_error("Preference type mismatch");
+        throw runtime_error("Preference type mismatch");
 
     return GetValueRaw<bool>();
 }
@@ -63,7 +65,7 @@ bool Preference::GetBool() const
 double Preference::GetReal() const
 {
     if(m_type != PreferenceType::Real)
-        throw std::runtime_error("Preference type mismatch");
+        throw runtime_error("Preference type mismatch");
 
     return GetValueRaw<double>();
 }
@@ -71,7 +73,7 @@ double Preference::GetReal() const
 const std::string& Preference::GetString() const
 {
     if(m_type != PreferenceType::String)
-        throw std::runtime_error("Preference type mismatch");
+        throw runtime_error("Preference type mismatch");
 
     return GetValueRaw<std::string>();
 }
@@ -79,10 +81,10 @@ const std::string& Preference::GetString() const
 void Preference::CleanUp()
 {
     if(m_type == PreferenceType::String)
-        (reinterpret_cast<std::string*>(&m_value))->~basic_string();
+        (reinterpret_cast<string*>(&m_value))->~basic_string();
 }
 
-std::string Preference::ToString() const
+string Preference::ToString() const
 {
     switch(m_type)
     {
@@ -91,17 +93,17 @@ std::string Preference::ToString() const
         case PreferenceType::Boolean:
             return GetBool() ? "true" : "false";
         case PreferenceType::Real:
-            return std::to_string(GetReal());
+            return to_string(GetReal());
         default:
-            throw std::runtime_error("tried to retrieve value from preference in moved-from state");
+            throw runtime_error("tried to retrieve value from preference in moved-from state");
     }
 }
 
 void Preference::MoveFrom(Preference& other)
 {
     m_type = other.m_type;
-    m_identifier = std::move(other.m_identifier);
-    m_description = std::move(other.m_description);
+    m_identifier = move(other.m_identifier);
+    m_description = move(other.m_description);
     
     switch(other.m_type)
     {
@@ -114,7 +116,7 @@ void Preference::MoveFrom(Preference& other)
             break;
             
         case PreferenceType::String:
-            Construct<std::string>(std::move(other.GetValueRaw<std::string>()));
+            Construct<string>(move(other.GetValueRaw<string>()));
             break;
             
         default:
@@ -136,8 +138,8 @@ void Preference::SetReal(double value)
     Construct<double>(value);
 }
 
-void Preference::SetString(std::string value)
+void Preference::SetString(string value)
 {
     CleanUp();
-    Construct<std::string>(std::move(value));
+    Construct<string>(move(value));
 }

--- a/glscopeclient/Preference.cpp
+++ b/glscopeclient/Preference.cpp
@@ -78,8 +78,8 @@ const std::string& Preference::GetString() const
 
 void Preference::CleanUp()
 {
-    //if(m_type == PreferenceType::String)
-    //    (reinterpret_cast<std::string*>(&m_value))->~basic_string();
+    if(m_type == PreferenceType::String)
+        (reinterpret_cast<std::string*>(&m_value))->~basic_string();
 }
 
 std::string Preference::ToString() const

--- a/glscopeclient/Preference.cpp
+++ b/glscopeclient/Preference.cpp
@@ -1,0 +1,77 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* ANTIKERNEL v0.1                                                                                                      *
+*                                                                                                                      *
+* Copyright (c) 2012-2018 Andrew D. Zonenberg                                                                          *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Katharina B.
+	@brief  Implementation of Preference
+ */
+ 
+#include <stdexcept>
+
+#include "Preference.h"
+
+const std::string& Preference::get_identifier() const
+{
+    return m_identifier;
+}
+
+const std::string& Preference::get_description() const
+{
+    return m_description;
+}
+
+PreferenceType Preference::get_type() const
+{
+    return m_type;
+}
+
+bool Preference::get_bool() const
+{
+    if(m_type != PreferenceType::Boolean)
+        throw std::runtime_error("Preference type mismatch");
+
+    return get_value_raw<bool>();
+}
+
+double Preference::get_real() const
+{
+    if(m_type != PreferenceType::Real)
+        throw std::runtime_error("Preference type mismatch");
+
+    return get_value_raw<double>();
+}
+
+const std::string& Preference::get_string() const
+{
+    if(m_type != PreferenceType::String)
+        throw std::runtime_error("Preference type mismatch");
+
+    return get_value_raw<std::string>();
+}

--- a/glscopeclient/Preference.cpp
+++ b/glscopeclient/Preference.cpp
@@ -91,8 +91,9 @@ std::string Preference::ToString() const
         case PreferenceType::Boolean:
             return GetBool() ? "true" : "false";
         case PreferenceType::Real:
-        default:
             return std::to_string(GetReal());
+        default:
+            throw std::runtime_error("tried to retrieve value from preference in moved-from state");
     }
 }
 

--- a/glscopeclient/Preference.h
+++ b/glscopeclient/Preference.h
@@ -33,8 +33,8 @@
 	@brief  Basic preference class and auxilliary types
  */
 
-#ifndef Preference_H
-#define Preference_H
+#ifndef Preference_h
+#define Preference_h
 
 #include <string>
 #include <type_traits>
@@ -148,4 +148,4 @@ private:
     PreferenceValue m_value;
 };
 
-#endif // Preference_H
+#endif // Preference_h

--- a/glscopeclient/Preference.h
+++ b/glscopeclient/Preference.h
@@ -1,0 +1,115 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* ANTIKERNEL v0.1                                                                                                      *
+*                                                                                                                      *
+* Copyright (c) 2012-2020 Andrew D. Zonenberg                                                                          *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Katharina B.
+	@brief  Basic preference class and auxilliary types
+ */
+
+#ifndef Preference_H
+#define Preference_H
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+constexpr std::size_t max(std::size_t a, std::size_t b)
+{
+    return (a > b) ? a : b;
+}
+
+enum class PreferenceType
+{
+    Boolean,
+    String,
+    Real
+};
+
+class Preference
+{
+private:
+    using PreferenceValue = typename std::aligned_union<
+        max(max(sizeof(bool), sizeof(double)), sizeof(std::string)),
+        bool, std::string, double
+    >::type;
+
+public:
+    // Taking string as value and then moving is intended
+    Preference(std::string identifier, std::string description, bool defaultValue)
+        :   m_identifier{std::move(identifier)}, m_description{std::move(description)},
+            m_type{PreferenceType::Boolean}
+    {
+        new (&m_value) bool(defaultValue);
+    }
+    
+    Preference(std::string identifier, std::string description, std::string defaultValue)
+        :   m_identifier{std::move(identifier)}, m_description{std::move(description)},
+            m_type{PreferenceType::String}
+    {
+        new (&m_value) std::string(std::move(defaultValue));
+    }
+    
+    Preference(std::string identifier, std::string description, double defaultValue)
+        :   m_identifier{std::move(identifier)}, m_description{std::move(description)},
+            m_type{PreferenceType::Real}
+    {
+        new (&m_value) double(defaultValue);
+    }
+    
+public:
+    Preference(const Preference&) = delete;
+    Preference(Preference&&) = default;
+    
+    Preference& operator=(const Preference&) = delete;
+    Preference& operator=(Preference&&) = default;
+    
+public:
+    const std::string& get_identifier() const;
+    const std::string& get_description() const;
+    PreferenceType get_type() const;
+    bool get_bool() const;
+    double get_real() const;
+    const std::string& get_string() const;
+    
+private:
+    template<typename T>
+    const T& get_value_raw() const
+    {
+        return *reinterpret_cast<const T*>(&m_value);
+    }
+    
+private:
+    std::string m_identifier;
+    std::string m_description;
+    PreferenceType m_type;
+    PreferenceValue m_value;
+};
+
+#endif // Preference_H

--- a/glscopeclient/Preference.h
+++ b/glscopeclient/Preference.h
@@ -77,6 +77,13 @@ public:
         new (&m_value) std::string(std::move(defaultValue));
     }
     
+    Preference(std::string identifier, std::string description, const char* defaultValue)
+        :   m_identifier{std::move(identifier)}, m_description{std::move(description)},
+            m_type{PreferenceType::String}
+    {
+        new (&m_value) std::string(defaultValue);
+    }
+    
     Preference(std::string identifier, std::string description, double defaultValue)
         :   m_identifier{std::move(identifier)}, m_description{std::move(description)},
             m_type{PreferenceType::Real}

--- a/glscopeclient/Preference.h
+++ b/glscopeclient/Preference.h
@@ -91,16 +91,16 @@ public:
     Preference& operator=(Preference&&) = default;
     
 public:
-    const std::string& get_identifier() const;
-    const std::string& get_description() const;
-    PreferenceType get_type() const;
-    bool get_bool() const;
-    double get_real() const;
-    const std::string& get_string() const;
+    const std::string& GetIdentifier() const;
+    const std::string& GetDescription() const;
+    PreferenceType GetType() const;
+    bool GetBool() const;
+    double GetReal() const;
+    const std::string& GetString() const;
     
 private:
     template<typename T>
-    const T& get_value_raw() const
+    const T& GetValueRaw() const
     {
         return *reinterpret_cast<const T*>(&m_value);
     }

--- a/glscopeclient/PreferenceManager.cpp
+++ b/glscopeclient/PreferenceManager.cpp
@@ -1,3 +1,31 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* ANTIKERNEL v0.1                                                                                                      *
+*                                                                                                                      *
+* Copyright (c) 2012-2020 Andrew D. Zonenberg                                                                          *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
 
 #include <fstream>
 
@@ -13,21 +41,23 @@
 #include "glscopeclient.h"
 #include "PreferenceManager.h"
 
+using namespace std;
+
 #ifndef _WIN32
 // POSIX-specific filesystem helpers. These will be moved to xptools in a generalized form later.
 
 // Expand things like ~ in path
-static std::string ExpandPath(const std::string& in)
+static std::string ExpandPath(const string& in)
 {
     wordexp_t result;
     wordexp(in.c_str(), &result, 0);
     auto expanded = result.we_wordv[0];
-    std::string out{ expanded };
+    string out{ expanded };
     wordfree(&result);
     return out;
 }
 
-static void CreateDirectory(const std::string& path)
+static void CreateDirectory(const string& path)
 {
     const auto expanded = ExpandPath(path);
 
@@ -40,13 +70,13 @@ static void CreateDirectory(const std::string& path)
         if(mkdir(expanded.c_str(), 0755) != 0 && errno != EEXIST)
         {
             perror("");
-            throw std::runtime_error("failed to create preferences directory");
+            throw runtime_error("failed to create preferences directory");
         }    
     }
     else if(!S_ISDIR(fst.st_mode))
     {
         // Exists, but is not a directory
-        throw std::runtime_error("preferences directory exists but is not a directory");
+        throw runtime_error("preferences directory exists but is not a directory");
     }
 }
 #endif
@@ -59,7 +89,7 @@ void PreferenceManager::InitializeDefaults()
     AddPreference("test_bool", "Third test value", true);
 }
 
-std::map<std::string, Preference>& PreferenceManager::AllPreferences()
+map<string, Preference>& PreferenceManager::AllPreferences()
 {
     return m_preferences;
 }
@@ -77,13 +107,13 @@ bool PreferenceManager::HasPreferenceFile() const
 #endif
 }
 
-const Preference& PreferenceManager::GetPreference(const std::string& identifier) const
+const Preference& PreferenceManager::GetPreference(const string& identifier) const
 {
     const auto it = m_preferences.find(identifier);
     
     if(it == m_preferences.end())
     {
-        throw std::runtime_error("tried to access non-existant preference");
+        throw runtime_error("tried to access non-existant preference");
     }
     else
     {
@@ -107,7 +137,7 @@ void PreferenceManager::DeterminePath()
     TCHAR directory[MAX_PATH];
     if(NULL == PathCombine(directory, stem, "glscopeclient"))
     {
-        throw std::runtime_error("failed to build directory path");
+        throw runtime_error("failed to build directory path");
     }
     
     // Ensure the directory exists
@@ -115,17 +145,17 @@ void PreferenceManager::DeterminePath()
     
     if(!result && GetLastError() != ERROR_ALREADY_EXISTS)
     {
-        throw std::runtime_error("failed to create preferences directory");
+        throw runtime_error("failed to create preferences directory");
     }
     
     // Build final path
     TCHAR config[MAX_PATH];
     if(NULL == PathCombine(config, directory, "preferences.yml"))
     {
-        throw std::runtime_error("failed to build directory path");
+        throw runtime_error("failed to build directory path");
     }
     
-    m_filePath = std::string(config);
+    m_filePath = string(config);
 #else
     // Ensure all directories in path exist
     CreateDirectory("~/.config");
@@ -135,17 +165,17 @@ void PreferenceManager::DeterminePath()
 #endif
 }
 
-const std::string& PreferenceManager::GetString(const std::string& identifier) const
+const std::string& PreferenceManager::GetString(const string& identifier) const
 {
     return GetPreference(identifier).GetString();
 }
 
-double PreferenceManager::GetReal(const std::string& identifier) const
+double PreferenceManager::GetReal(const string& identifier) const
 {
     return GetPreference(identifier).GetReal();
 }
 
-bool PreferenceManager::GetBool(const std::string& identifier) const
+bool PreferenceManager::GetBool(const string& identifier) const
 {
     return GetPreference(identifier).GetBool();
 }
@@ -178,7 +208,7 @@ void PreferenceManager::LoadPreferences()
                         break;
                         
                     case PreferenceType::String:
-                        preference.SetString(node.as<std::string>());
+                        preference.SetString(node.as<string>());
                         break;
                         
                     default:
@@ -187,7 +217,7 @@ void PreferenceManager::LoadPreferences()
             }
         }
     }
-    catch(const std::exception& ex)
+    catch(const exception& ex)
     {
         LogWarning("Warning: Preference file was present, but couldn't be read. Ignoring. (%s)", ex.what());
     }
@@ -202,7 +232,7 @@ void PreferenceManager::SavePreferences()
         node[entry.first] = entry.second.ToString();
     }
     
-    std::ofstream outfs{ m_filePath };
+    ofstream outfs{ m_filePath };
     
     if(!outfs)
     {

--- a/glscopeclient/PreferenceManager.cpp
+++ b/glscopeclient/PreferenceManager.cpp
@@ -93,8 +93,10 @@ void PreferenceManager::LoadPreferences()
                         break;
                         
                     case PreferenceType::String:
-                    default:
                         preference.SetString(node.as<std::string>());
+                        break;
+                        
+                    default:
                         break;
                 }
             }

--- a/glscopeclient/PreferenceManager.cpp
+++ b/glscopeclient/PreferenceManager.cpp
@@ -14,7 +14,10 @@
 #include "PreferenceManager.h"
 
 #ifndef _WIN32
-static std::string ExpandDirectory(const std::string& in)
+// POSIX-specific filesystem helpers. These will be moved to xptools in a generalized form later.
+
+// Expand things like ~ in path
+static std::string ExpandPath(const std::string& in)
 {
     wordexp_t result;
     wordexp(in.c_str(), &result, 0);
@@ -26,7 +29,7 @@ static std::string ExpandDirectory(const std::string& in)
 
 static void CreateDirectory(const std::string& path)
 {
-    const auto expanded = ExpandDirectory(path);
+    const auto expanded = ExpandPath(path);
 
     struct stat fst{ };
     
@@ -128,7 +131,7 @@ void PreferenceManager::DeterminePath()
     CreateDirectory("~/.config");
     CreateDirectory("~/.config/glscopeclient");
 
-    m_filePath = ExpandDirectory("~/.config/glscopeclient/preferences.yml");
+    m_filePath = ExpandPath("~/.config/glscopeclient/preferences.yml");
 #endif
 }
 

--- a/glscopeclient/PreferenceManager.cpp
+++ b/glscopeclient/PreferenceManager.cpp
@@ -1,0 +1,133 @@
+
+#include <fstream>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <shlwapi.h>
+#else
+#include <sys/stat.h>
+#endif
+
+#include "glscopeclient.h"
+#include "PreferenceManager.h"
+
+void PreferenceManager::InitializeDefaults()
+{
+    AddPreference("test_string", "First test value", "string");
+    AddPreference("test_real", "Second test value", 42.09);
+    AddPreference("test_bool", "Third test value", true);
+}
+
+std::map<std::string, Preference>& PreferenceManager::AllPreferences()
+{
+    return m_preferences;
+}
+
+bool PreferenceManager::HasPreferenceFile() const
+{
+#ifdef _WIN32
+    const auto fattr = GetFileAttributes(m_filePath.c_str());
+    return (fattr !0 INVALID_FILE_ATTRIBUTE) && !(fattr & FILE_ATTRIBUTE_DIRECTORY);
+#else
+    struct stat fs{ };
+    const auto result = stat(m_filePath.c_str(), &fs);
+    
+    return (result == 0) && (fs.st_mode & S_IFREG);
+#endif
+}
+
+const Preference& PreferenceManager::GetPreference(const std::string& identifier) const
+{
+    const auto it = m_preferences.find(identifier);
+    
+    if(it == m_preferences.end())
+    {
+        throw std::runtime_error("tried to access non-existant preference");
+    }
+    else
+    {
+        return it->second;
+    }
+}
+
+const std::string& PreferenceManager::GetString(const std::string& identifier) const
+{
+    return GetPreference(identifier).GetString();
+}
+
+double PreferenceManager::GetReal(const std::string& identifier) const
+{
+    return GetPreference(identifier).GetReal();
+}
+
+bool PreferenceManager::GetBool(const std::string& identifier) const
+{
+    return GetPreference(identifier).GetBool();
+}
+
+void PreferenceManager::LoadPreferences()
+{
+    if(!HasPreferenceFile())
+        return;
+
+    try
+    {
+        auto doc = YAML::LoadAllFromFile(m_filePath)[0];
+    
+        for(auto& entry: m_preferences)
+        {
+            // Check if the preferences file contains an entry with that matches the
+            // current preference identifier. If so, we overwrite the stored default value.
+            if(const auto& node = doc[entry.first])
+            {
+                auto& preference = entry.second;
+            
+                switch(preference.GetType())
+                {
+                    case PreferenceType::Boolean:
+                        preference.SetBool(node.as<bool>());
+                        break;
+                        
+                    case PreferenceType::Real:
+                        preference.SetReal(node.as<double>());
+                        break;
+                        
+                    case PreferenceType::String:
+                    default:
+                        preference.SetString(node.as<std::string>());
+                        break;
+                }
+            }
+        }
+    }
+    catch(const std::exception& ex)
+    {
+        LogWarning("Warning: Preference file was present, but couldn't be read. Ignoring. (%s)", ex.what());
+    }
+}
+
+void PreferenceManager::SavePreferences()
+{
+    YAML::Node node{ };
+    
+    for(const auto& entry: m_preferences)
+    {
+        node[entry.first] = entry.second.ToString();
+    }
+    
+    std::ofstream outfs{ m_filePath };
+    
+    if(!outfs)
+    {
+        LogError("couldn't open preferences file for writing");
+        return;
+    }
+    
+    outfs << node;
+    outfs.close();
+    
+    if(!outfs)
+    {
+        LogError("couldn't write preferences file to disk");
+    }
+}

--- a/glscopeclient/PreferenceManager.h
+++ b/glscopeclient/PreferenceManager.h
@@ -51,14 +51,24 @@ public:
     }
     
 public:
+    // Disallow copy
+    PreferenceManager(const PreferenceManager&) = delete;
+    PreferenceManager(PreferenceManager&&) = default;
+    
+    PreferenceManager& operator=(const PreferenceManager&) = delete;
+    PreferenceManager& operator=(PreferenceManager&&) = default;
+    
+public:
     void SavePreferences();
     std::map<std::string, Preference>& AllPreferences();
     
+    // Value retrieval methods
     const std::string& GetString(const std::string& identifier) const;
     double GetReal(const std::string& identifier) const;
     bool GetBool(const std::string& identifier) const;
     
 private:
+    // Internal helpers
     void DeterminePath();
     void InitializeDefaults();
     void LoadPreferences();

--- a/glscopeclient/PreferenceManager.h
+++ b/glscopeclient/PreferenceManager.h
@@ -43,9 +43,9 @@
 class PreferenceManager
 {
 public:
-    PreferenceManager(std::string filePath)
-        : m_filePath{std::move(filePath)}
+    PreferenceManager()
     {
+        DeterminePath();
         InitializeDefaults();
         LoadPreferences();
     }
@@ -59,6 +59,7 @@ public:
     bool GetBool(const std::string& identifier) const;
     
 private:
+    void DeterminePath();
     void InitializeDefaults();
     void LoadPreferences();
     bool HasPreferenceFile() const;

--- a/glscopeclient/PreferenceManager.h
+++ b/glscopeclient/PreferenceManager.h
@@ -33,8 +33,8 @@
 	@brief  Stores and manages preference values
  */
 
-#ifndef PreferenceManager_H
-#define PreferenceManager_H
+#ifndef PreferenceManager_h
+#define PreferenceManager_h
 
 #include <map>
 #include <string>
@@ -87,4 +87,4 @@ private:
     std::string m_filePath;
 };
 
-#endif // PreferenceManager_H
+#endif // PreferenceManager_h

--- a/glscopeclient/main.cpp
+++ b/glscopeclient/main.cpp
@@ -53,6 +53,8 @@
 #include <iostream>
 #include <thread>
 
+#include "PreferenceManager.h"
+
 using namespace std;
 
 //for color selection
@@ -104,6 +106,10 @@ void help()
 
 int main(int argc, char* argv[])
 {
+    PreferenceManager mgr{ "test.yml" };
+    mgr.SavePreferences();
+
+
 	//Global settings
 	Severity console_verbosity = Severity::NOTICE;
 

--- a/glscopeclient/main.cpp
+++ b/glscopeclient/main.cpp
@@ -106,10 +106,6 @@ void help()
 
 int main(int argc, char* argv[])
 {
-    PreferenceManager mgr{ };
-    mgr.SavePreferences();
-
-
 	//Global settings
 	Severity console_verbosity = Severity::NOTICE;
 

--- a/glscopeclient/main.cpp
+++ b/glscopeclient/main.cpp
@@ -106,7 +106,7 @@ void help()
 
 int main(int argc, char* argv[])
 {
-    PreferenceManager mgr{ "test.yml" };
+    PreferenceManager mgr{ };
     mgr.SavePreferences();
 
 


### PR DESCRIPTION
This PR implements:
- The `Preference` class, which holds a single preference value and its metadata in form a sum type
- The `PreferenceManager` class which
    - Manages and stores all known preferences
    - Initializes them with default values
    - Path handling and creation for both Windows and POSIX
    - Loads existing values from disk
    - Provides facilities to retrieve values by their identifier
    - Allows saving of preferences back to disk
- Basic integration into `OscilloscopeWindow`