### PR TITLE
include chrono required for refactoring of usleep

### DIFF
--- a/src/glscopeclient/glscopeclient.h
+++ b/src/glscopeclient/glscopeclient.h
@@ -43,6 +43,7 @@
 #include "../scopehal/OscilloscopeChannel.h"
 #include "../scopehal/Filter.h"
 
+#include <chrono>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
include chrono required for refactoring of usleep(..) by std::this_thread::sleep_for(std::chrono::microseconds(..))