### PR TITLE
Add *.bin filter to Import dialog

### DIFF
--- a/src/glscopeclient/OscilloscopeWindow.h
+++ b/src/glscopeclient/OscilloscopeWindow.h
@@ -239,6 +239,7 @@ public:
 	void DoFileOpen(const std::string& filename, bool loadLayout = true, bool loadWaveform = true, bool reconnect = true);
 	void OnFileImport();
 	void DoImportCSV(const std::string& filename);
+	void DoImportBIN(const std::string& filename);
 	void LoadInstruments(const YAML::Node& node, bool reconnect, IDTable& table);
 	void LoadDecodes(const YAML::Node& node, IDTable& table);
 	void LoadUIConfiguration(const YAML::Node& node, IDTable& table);

--- a/src/glscopeclient/ScopeApp.cpp
+++ b/src/glscopeclient/ScopeApp.cpp
@@ -53,9 +53,12 @@ void ScopeApp::run(string fileToLoad, bool reconnect, bool nodata, bool retrigge
 	//Handle file loads specified on the command line
 	if(!fileToLoad.empty())
 	{
-		//Guess CSV files by extension
+		//Guess files by extension
 		if(fileToLoad.find(".csv") != string::npos)
 			m_window->DoImportCSV(fileToLoad);
+
+		else if (fileToLoad.find(".bin") != string::npos)
+			m_window->DoImportBIN(fileToLoad);
 
 		//Assume anything else is a scopesession
 		else


### PR DESCRIPTION
This PR adds a `*.bin` filter to the Import File dialog for Agilent, Keysight and Rigol multi-channel binary waveform capture files.

`DoImportCSV()` and `DoImportBIN()` are very similar and could probably be refactored down into `DoFileImport()`. I didn't have any CSVs to test with so I focused on getting the BIN import working on its own.

See related PR azonenberg/scopehal#396 for BIN file parser.