### PR TITLE
Use make install on Windows (MSYS2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,7 @@ jobs:
           mingw-w64-x86_64-gtkmm3
           mingw-w64-x86_64-yaml-cpp
           mingw-w64-x86_64-glew
+          tree
 
     - name: Build and install FFTS Library
       run: |
@@ -158,22 +159,19 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake \
+        MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
           -G"MSYS Makefiles" \
+          -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX \
           -DBUILD_TESTING=OFF \
           ..
         make -j4
+
+        mkdir dist
+        make DESTDIR=dist install
+        tree dist
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: glscopeclient-windows
-        path: |
-          build/src/glscopeclient/glscopeclient.exe
-          build/src/glscopeclient/gradients/*
-          build/src/glscopeclient/shaders/*
-          build/src/glscopeclient/styles/*
-          build/lib/graphwidget/libgraphwidget.dll
-          build/lib/log/liblog.dll
-          build/lib/scopehal/libscopehal.dll
-          build/lib/scopeprotocols/libscopeprotocols.dll
+        path: build/dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,9 @@ jobs:
 
     steps:
 
+    - run: git config --global core.autocrlf input
+      shell: bash
+
     - uses: actions/checkout@v2
       with:
         submodules: recursive
@@ -145,19 +148,11 @@ jobs:
           mingw-w64-x86_64-yaml-cpp
           mingw-w64-x86_64-glew
 
-    - name: Clone and Build FFTS Library
+    - name: Build and install FFTS Library
       run: |
-        git clone https://github.com/anthonix/ffts.git ../ffts
-        cd ../ffts
-        mkdir build
-        cd build
-        cmake \
-          -G"MSYS Makefiles" \
-          -DCMAKE_INSTALL_PREFIX=$MSYSTEM_PREFIX \
-          -DENABLE_SHARED=ON \
-          ..
-        make -j4
-        make install
+        cd msys2/mingw-w64-ffts
+        MINGW_ARCH=mingw64 makepkg-mingw --noconfirm --noprogressbar -sCLf --nocheck
+        pacman -U --noconfirm *.zst
 
     - name: Build
       run: |

--- a/msys2/mingw-w64-ffts/PKGBUILD
+++ b/msys2/mingw-w64-ffts/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: umarcor <unai.martinezcorral@ehu.eus>
+
+_realname=ffts
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=master
+pkgrel=1
+pkgdesc="ffts: The Fastest Fourier Transform in the South  (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
+url="https://github.com/anthonix/ffts"
+license=('custom')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+)
+
+source=("${_realname}::git://github.com/anthonix/ffts.git#commit=master")
+sha256sums=('SKIP')
+
+build() {
+  cd "${srcdir}/${_realname}"
+  mkdir build
+  cd build
+  MSYS2_ARG_CONV_EXCL=- cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DENABLE_SHARED=ON \
+    ../
+  cmake --build .
+}
+
+package() {
+  cd "${srcdir}/${_realname}"/build
+  make DESTDIR="${pkgdir}" install
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${srcdir}/${_realname}"/COPYRIGHT "${_licenses}"
+}


### PR DESCRIPTION
The first commit in this PR adds a PKGBUILD recipe for building and installing FFTS, instead of doing it manually. The recipe is equivalent to the ones used upstream, but the main branch is built, instead of using a fixed commit.

Then, make install is used for packaging the MSYS2 build of scopehal-apps, instead of manually specifying the artifacts to be uploaded. The result looks almost correct, but `liblog.dll` is missing:

```
dist
└── mingw64
    ├── bin
    │   ├── glscopeclient.exe
    │   ├── libgraphwidget.dll
    │   ├── libscopehal.dll
    │   └── libscopeprotocols.dll
    ├── lib
    │   ├── libgraphwidget.dll.a
    │   ├── libscopehal.dll.a
    │   └── libscopeprotocols.dll.a
    └── share
        ├── applications
        │   └── glscopeclient.desktop
        └── glscopeclient
            ├── gradients
            │   ├── eye-gradient-crt.rgba
            │   ├── eye-gradient-grayscale.rgba
            │   ├── eye-gradient-ironbow.rgba
            │   ├── eye-gradient-krain.rgba
            │   ├── eye-gradient-rainbow.rgba
            │   └── eye-gradient-viridis.rgba
            ├── icons
            │   ├── 24x24
            │   │   ├── clear-sweeps.png
            │   │   ├── fullscreen-enter.png
            │   │   ├── fullscreen-exit.png
            │   │   ├── history.png
            │   │   ├── refresh-settings.png
            │   │   ├── trigger-single.png
            │   │   ├── trigger-start.png
            │   │   └── trigger-stop.png
            │   ├── 48x48
            │   │   ├── clear-sweeps.png
            │   │   ├── fullscreen-enter.png
            │   │   ├── fullscreen-exit.png
            │   │   ├── history.png
            │   │   ├── refresh-settings.png
            │   │   ├── trigger-single.png
            │   │   ├── trigger-start.png
            │   │   └── trigger-stop.png
            │   └── scalable
            │       ├── clear-sweeps.svg
            │       ├── fullscreen-enter.svg
            │       ├── fullscreen-exit.svg
            │       ├── history.svg
            │       ├── refresh-settings.svg
            │       ├── trigger-single.svg
            │       ├── trigger-start.svg
            │       └── trigger-stop.svg
            ├── kernels
            │   ├── DeEmbedFilter.cl
            │   ├── FFTNormalization.cl
            │   ├── FIRFilter.cl
            │   └── WindowFunctions.cl
            ├── shaders
            │   ├── cairo-fragment.glsl
            │   ├── cairo-vertex.glsl
            │   ├── colormap-fragment.glsl
            │   ├── colormap-vertex.glsl
            │   ├── eye-fragment.glsl
            │   ├── eye-vertex.glsl
            │   ├── spectrogram-fragment.glsl
            │   ├── spectrogram-vertex.glsl
            │   ├── waveform-compute-analog.glsl
            │   ├── waveform-compute-core.glsl
            │   ├── waveform-compute-digital.glsl
            │   ├── waveform-compute-head.glsl
            │   ├── waveform-compute-head-noint64.glsl
            │   └── waveform-compute-histogram.glsl
            └── styles
                └── glscopeclient.css
```

