### PR TITLE
Driver selection dialog polish

### DIFF
--- a/src/glscopeclient/InstrumentConnectionDialog.cpp
+++ b/src/glscopeclient/InstrumentConnectionDialog.cpp
@@ -118,14 +118,17 @@ bool InstrumentConnectionDialog::ValidateConfig()
 		return false;
 	if(m_transportBox.get_active_text() == "")
 		return false;
-	if(m_pathEntry.get_text() == "")
+	if(m_pathEntry.get_text() == "" && m_transportBox.get_active_text() != "null")
 		return false;
 
 	//For now, hard code check of null being legal only with siggen/demo
 	if(m_transportBox.get_active_text() != "null")
 		return true;
-	if( (m_driverBox.get_active_text() == "siggen") || (m_driverBox.get_active_text() == "demo") )
+	if( (m_driverBox.get_active_text() == "siggen") || (m_driverBox.get_active_text() == "demo") ){
+		if(m_pathEntry.get_text() == "")
+			m_pathEntry.set_text("null");
 		return true;
+	}
 
 	return false;
 }

--- a/src/glscopeclient/InstrumentConnectionDialog.cpp
+++ b/src/glscopeclient/InstrumentConnectionDialog.cpp
@@ -66,7 +66,8 @@ InstrumentConnectionDialog::InstrumentConnectionDialog()
 	vector<string> drivers;
 	Oscilloscope::EnumDrivers(drivers);
 	for(auto d : drivers)
-		m_driverBox.append(d);
+		if(d != "siggen")
+			m_driverBox.append(d);
 
 	m_grid.attach_next_to(m_transportLabel, m_driverLabel, Gtk::POS_BOTTOM, 1, 1);
 		m_transportLabel.set_text("Transport");

--- a/src/glscopeclient/main.cpp
+++ b/src/glscopeclient/main.cpp
@@ -228,7 +228,7 @@ int main(int argc, char* argv[])
 					"\n"
 					"A driver and transport must always be selected.\n"
 					"\n"
-					"The NULL transport is only legal with the \"siggen\" or \"demo\" driver.",
+					"The NULL transport is only legal with the \"demo\" driver.",
 					false,
 					Gtk::MESSAGE_ERROR,
 					Gtk::BUTTONS_OK,


### PR DESCRIPTION
Confusing error message when null transport is selected with no path entered - fixed by setting path to "null" in that case.
Removed siggen driver from GUI driver list because it segfaults on startup. Removed "siggen" from null transport error message.