### PR TITLE
ci: use msys2 recipe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,41 +132,28 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - uses: msys2/setup-msys2@v2
       with:
         update: true
         msystem: MINGW64
-        install: >-
+        install: |
           git
-          make
-          mingw-w64-x86_64-cmake
-          mingw-w64-x86_64-ffts
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-glew
-          mingw-w64-x86_64-glm
-          mingw-w64-x86_64-gtkmm3
-          mingw-w64-x86_64-libsigc++
-          mingw-w64-x86_64-yaml-cpp
-          tree
+          mingw-w64-x86_64-toolchain
 
     - name: Build
       run: |
-        mkdir build
-        cd build
-        MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" cmake \
-          -G"MSYS Makefiles" \
-          -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX \
-          -DBUILD_TESTING=OFF \
-          ..
-        make -j4
+        cd msys2
+        MINGW_ARCH=mingw64 makepkg-mingw --noconfirm --noprogressbar -sCLf
 
-        mkdir dist
-        make DESTDIR=dist install
-        tree dist
+    - name: Test
+      run: |
+        pacman -U --noconfirm msys2/*.zst
+        glscopeclient --help
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: glscopeclient-windows
-        path: build/dist
+        path: msys2/*.zst

--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -1,0 +1,54 @@
+_realname=scopehal-apps
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=ci
+pkgrel=1
+pkgdesc="scopehal-apps: applications for libscopehal (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64')
+url="https://github.com/azonenberg/scopehal-apps"
+license=('BSD-3-Clause')
+groups=("${MINGW_PACKAGE_PREFIX}-eda")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-glm"
+  "${MINGW_PACKAGE_PREFIX}-libsigc++"
+  "${MINGW_PACKAGE_PREFIX}-gtkmm3"
+  "${MINGW_PACKAGE_PREFIX}-yaml-cpp"
+  "${MINGW_PACKAGE_PREFIX}-glew"
+  "${MINGW_PACKAGE_PREFIX}-ffts"
+)
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "make"
+)
+
+pkgver() {
+  cd "${srcdir}"/../..
+  echo '0.0.0.r'"$(git rev-list --count HEAD)"'.g'"$(git describe --all --long | sed 's/^.*-g\(.*\)/\1/')"
+}
+
+build() {
+  cd "${srcdir}"/../..
+
+  git remote set-url origin git://github.com/azonenberg/scopehal-apps
+  git submodule update --init --recursive
+
+  mkdir build
+  cd build
+  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DBUILD_TESTING=OFF \
+    ../
+  cmake --build .
+}
+
+package() {
+  cd "${srcdir}"/../../build
+  make DESTDIR="${pkgdir}" install
+
+  _licenses="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  mkdir -p "${_licenses}"
+  install -m 644 "${srcdir}"/../../LICENSE "${_licenses}"
+}


### PR DESCRIPTION
Instead of writing the build steps manually in the CI workflow, in this PR a PKGBUILD recipe is added. The recipe is similar to the one used in [msys2/MINGW-packages](https://github.com/msys2/MINGW-packages). However, instead of a pinned version, here the checked out version is built.

This is blocked by azonenberg/scopehal-docs#31.