### PR TITLE
Fix null pointer dereference in graph editor

### DIFF
--- a/src/glscopeclient/FilterGraphEditorWidget.cpp
+++ b/src/glscopeclient/FilterGraphEditorWidget.cpp
@@ -1269,6 +1269,7 @@ void FilterGraphEditorWidget::OnRightClick(GdkEventButton* event)
 {
 	//Update display with the node we clicked on highlighted
 	m_selectedNode = HitTestNode(event->x, event->y);
+	m_dragMode = DRAG_NONE;
 	queue_draw();
 
 	m_contextMenu.popup(event->button, event->time);


### PR DESCRIPTION
When right clicking while dragging onto nothing, the selected node gets
set to NULL, but the node rendering assumes the selected node to be
valid during a drag.

The drag is now just canceled on a right click.