### PR TITLE
Set Clang specific parameters for Apple Clang too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(WARNINGS "${WARNINGS} -Wmissing-declarations -Wvla")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(WARNINGS "${WARNINGS} ")
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   set(WARNINGS "${WARNINGS} -Wno-gnu-zero-variadic-macro-arguments")
 endif()
 
@@ -28,7 +28,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 # clang doesn't properly use the attributes and so requires avx to build
 # should get fixed in #475
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
 endif()
 


### PR DESCRIPTION
CMake from 3.0 on distinguishes between normal clang, and Apple's clang: https://cmake.org/cmake/help/latest/policy/CMP0025.html
So, for any clang specific flags, we need to check for both.

This depends on https://github.com/azonenberg/scopehal/pull/513 to fix all build issues I could find.