### PR TITLE
WaveformArea: Ignore GLX errors for Wayland

### DIFF
--- a/src/glscopeclient/WaveformArea.cpp
+++ b/src/glscopeclient/WaveformArea.cpp
@@ -36,6 +36,7 @@
 #include "WaveformArea.h"
 #include "OscilloscopeWindow.h"
 #include <random>
+#include <stdlib.h>
 #include "../../lib/scopeprotocols/scopeprotocols.h"
 
 using namespace std;
@@ -504,7 +505,19 @@ void WaveformArea::on_realize()
 
 		//Initialize GLEW
 		GLenum glewResult = glewInit();
-		if (glewResult != GLEW_OK)
+
+		//The glewInit function doesn't allow runtime detection between GLX and
+		//EGL that is used by Wayland. It will default to GLX and return the
+		//_NO_GLX_DISPLAY error when running under Wayland. We can ignore this
+		//error since we don't need the GLX/EGL entry points and the GLX query for
+		//ARB works on EGL as well.
+		//See https://github.com/nigels-com/glew/issues/172
+		//
+		//TODO: Call glewContextInit() instead of glewInit, and remove the
+		//Wayland check once we rely on GLEW 2.2.0 (the first release that
+		//exposes glewContextInit).
+		if(glewResult != GLEW_OK
+			&& !( getenv("WAYLAND_DISPLAY") && glewResult == GLEW_ERROR_NO_GLX_DISPLAY) )
 		{
 			string err =
 				"glscopeclient was unable to initialize GLEW and cannot continue.\n"


### PR DESCRIPTION
With this change, I can start glscopeclient on my Ubuntu 21.04 laptop. I can open the demo device and display the waveforms.

It relies on the undocumented behavior that libglew is properly initialized, even though it has reported GLEW_ERROR_NO_GLX_DISPLAY.

Here's the definition glewInit for the 2.0.0 release dating back to 2016. It has stayed the same AFAICT in 2.1.0 and 2.2.0: https://github.com/nigels-com/glew/blob/glew-2.0.0/auto/src/glew_init_tail.c#L35 

I have libglew-dev 2.1.0-4 installed.

It's a hack that hopefully can be removed once GLEW 2.2.0 has trickled down through to the different distributions packet repositories. Then we can just call glewContextInit on wayland. 

Closes #277 
