### PR TITLE
Use ImGui's native DPI scaling.

### DIFF
--- a/src/ngscopeclient/VulkanWindow.cpp
+++ b/src/ngscopeclient/VulkanWindow.cpp
@@ -83,6 +83,8 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
 	io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 	io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
+	io.ConfigDpiScaleFonts = true;
+	io.ConfigDpiScaleViewports = true;
 
 	//Don't serialize UI config for now
 	//TODO: serialize to scopesession or something? https://github.com/ocornut/imgui/issues/4294
@@ -181,18 +183,6 @@ VulkanWindow::VulkanWindow(const string& title, shared_ptr<QueueHandle> queue)
 		info.Queue = **lock;
 		ImGui_ImplVulkan_Init(&info);
 	}
-
-	//Apply DPI scaling now that glfw initialized
-	//This appears to be cached by glfw at init time and is not updated for dynamic scaling changes at least on X11
-	//TODO: can we fix this by moving to SDL?
-	float scale = GetContentScale();
-	LogTrace("Using ImGui style scale factor: %.2f\n", scale);
-
-	//Per comment in imgui_impl_glfw "Apple platforms use FramebufferScale"
-	//On everything else use FontScaleMain
-#ifndef __APPLE__
-	ImGui::GetStyle().FontScaleMain = scale;
-#endif
 
 	//Hook a couple of backend functions with mutexing
 	ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
@@ -440,16 +430,6 @@ bool VulkanWindow::UpdateFramebuffer()
 
 	m_resizeEventPending = false;
 	return true;
-}
-
-float VulkanWindow::GetContentScale()
-{
-	float xscale;
-	float yscale;
-	glfwGetWindowContentScale(m_window, &xscale, &yscale);
-
-	// Hope this works well should a screen have unequal X- and Y- DPIs...
-	return (xscale + yscale) / 2;
 }
 
 void VulkanWindow::Render()


### PR DESCRIPTION
This fixes #868. It also fixes an issue I was seeing where the scaling factor set in the OS was being rounded to the nearest integer factor (e.g. I use a 165% scaling factor, but ngscopeclient was rendering at 200%).

Dear ImGui added native support for DPI scaling in release 1.92 (June 2025). See [their new FAQ entry on DPI handling](https://github.com/ocornut/imgui/blob/5f6eaa5278aa56075f6b001105e2e7dde9cc82ce/docs/FAQ.md#q-how-should-i-handle-dpi-in-my-application). That feature is still experimental and so it could break on future ImGui updates, but it seems to work much better than what we were doing before.

It [looks like the ImGUI GLFW backend already has the necessary conditionals to disable scaling on macOS](https://github.com/ngscopeclient/imgui/blob/371ea565ef0e925418987862b65580c8a10830b9/backends/imgui_impl_glfw.cpp#L1005-L1027), so I didn't disable the DPI awareness settings on that platform like we did before.