### PR TITLE
Fix Window->Multimeter submenu being always empty

### DIFF
--- a/src/ngscopeclient/MainWindow_Menus.cpp
+++ b/src/ngscopeclient/MainWindow_Menus.cpp
@@ -779,7 +779,7 @@ void MainWindow::WindowMultimeterMenu()
 {
 	//This is a bit of a hack but all of the dialogs are gonna get redone eventually so
 	vector< shared_ptr<SCPIMultimeter> > meters;
-	auto insts = m_session.GetScopes();
+	auto insts = m_session.GetSCPIInstruments();
 	for(auto inst : insts)
 	{
 		//Skip anything that's not a multimeter


### PR DESCRIPTION
While developing a driver a multimeter, I noticed that I wasn't able to re-open the window for it after closing it because the menu looked only for scopes, not DMMs, this fixes it.
