### PR TITLE
R&S RTB2000 oscilloscope driver - setup

### DIFF
--- a/src/ngscopeclient/PreferenceSchema.cpp
+++ b/src/ngscopeclient/PreferenceSchema.cpp
@@ -469,6 +469,22 @@ void PreferenceManager::InitializeDefaults()
 					.EnumValue("16 bits", WIDTH_16_BITS)
 				);
 
+		auto& rsrtb = drivers.AddCategory("RohdeSchwarz RTB");
+			rsrtb.AddPreference(
+				Preference::Enum("data_width", WIDTH_16_BITS)
+					.Label("Data Width")
+					.Description(
+					"Data width used when downloading sample data from the instrument.\n\n"
+					"Even if the instrument has a 10-bit ADC, using 8 rather than 16 bit data format allows faster"
+					" waveform update rate.\n\n"
+					"Choose 16 bit mode if you want to privilege data accuracy over refresh rate.\n\n"
+					"Changes to this setting take effect the next time a connection to the instrument is opened; "
+					"the transfer format for active sessions is not updated."
+						)
+					.EnumValue("8 bits", WIDTH_8_BITS)
+					.EnumValue("16 bits", WIDTH_16_BITS)
+				);
+
 		auto& siglent = drivers.AddCategory("Siglent SDS HD");
 			siglent.AddPreference(
 				Preference::Enum("data_width", WIDTH_AUTO)

--- a/src/ngscopeclient/Session.cpp
+++ b/src/ngscopeclient/Session.cpp
@@ -47,6 +47,7 @@
 
 #include "../scopehal/LeCroyOscilloscope.h"
 #include "../scopehal/SiglentSCPIOscilloscope.h"
+#include "../scopehal/RSRTB2kOscilloscope.h"
 #include "../scopehal/RigolOscilloscope.h"
 #include "../scopehal/MockOscilloscope.h"
 #include "../scopeprotocols/EyePattern.h"
@@ -2849,6 +2850,19 @@ void Session::ApplyPreferences(shared_ptr<Oscilloscope> scope)
 		else if(dataWidth == WIDTH_16_BITS)
 		{
 			siglent->ForceHDMode(true);
+		}
+	}
+	auto rsrtb = dynamic_pointer_cast<RSRTB2kOscilloscope>(scope);
+	if(rsrtb)
+	{
+		auto dataWidth = m_preferences.GetEnumRaw("Drivers.RohdeSchwarz RTB.data_width");
+		if(dataWidth == WIDTH_8_BITS)
+		{
+			rsrtb->ForceHDMode(false);
+		}
+		else if(dataWidth == WIDTH_16_BITS)
+		{
+			rsrtb->ForceHDMode(true);
 		}
 	}
 	auto rigol = dynamic_pointer_cast<RigolOscilloscope>(scope);


### PR DESCRIPTION
In the driver for the RTB2000 oscilloscope, you can choose between 8-bit and 16-bit resolution for the measurement curves.

Modified files:
ngscopeclient/PreferenceSchema.cpp
ngscopeclient/Session.cpp