### PR TITLE
Add Autofit popup menu on X-axis

### DIFF
--- a/src/ngscopeclient/WaveformGroup.h
+++ b/src/ngscopeclient/WaveformGroup.h
@@ -136,6 +136,8 @@ public:
 	bool IsDraggingTrigger()
 	{ return m_dragState == DRAG_STATE_TRIGGER; }
 
+	void AutofitHorizontal(float width);
+
 protected:
 	void RenderTimeline(float width, float height);
 	void RenderTriggerPositionArrows(ImVec2 pos, float height);


### PR DESCRIPTION
When right-clicking on the X-axis of a WaveformGroup, you will now get an "Autofit" pop-up menu. When clicked, it performs the same operation as clicking the middle mouse button: all WaveformAreas are rescaled so that they fit.

This fix make it possible to use Autofit when using a laptop/trackpad that doesn't have a middle click button.