### PR TITLE
Add context popup on vertical axis menu to autofit.

### DIFF
--- a/src/ngscopeclient/WaveformArea.h
+++ b/src/ngscopeclient/WaveformArea.h
@@ -496,6 +496,8 @@ public:
 	bool IsChannelBeingDragged();
 	StreamDescriptor GetChannelBeingDragged();
 
+	void AutofitVertical();
+
 	/**
 		@brief Gets the WaveformGroup for this area
 	 */


### PR DESCRIPTION
This PR implement the same functionality as PR #955, but for the Y-axis.

While it does the same thing as using the middle-button on a mouse, the general functionality is currently a bit broken: when clicking the middle button, the waves aren't redraw, so all you see is a change in the Y-axis numbers.

But at least trackpad users have now access to the same broken functionality. :-)