### PR TITLE
Model information (supported transport and connection string) in AddInstrumentDialog

### DIFF
--- a/src/ngscopeclient/AddInstrumentDialog.h
+++ b/src/ngscopeclient/AddInstrumentDialog.h
@@ -37,6 +37,7 @@
 
 #include "Dialog.h"
 #include "Session.h"
+#include <unordered_set>
 
 class AddInstrumentDialog : public Dialog
 {
@@ -59,13 +60,22 @@ protected:
 
 	virtual bool DoConnect(SCPITransport* transport);
 
+	void UpdateCombos();
 	//GUI widget values
 	std::string m_nickname;
+	std::string m_originalNickname;
+	std::string m_defaultNickname;
+	bool m_nicknameEdited;
 	int m_selectedDriver;
 	std::vector<std::string> m_drivers;
 	int m_selectedTransport;
 	std::vector<std::string> m_transports;
+	int m_selectedModel;
+	std::vector<std::string> m_models;
+	std::unordered_set<std::string> m_supportedTransports;
 	std::string m_path;
+	std::string m_defaultPath;
+	bool m_pathEdited;
 };
 
 #endif


### PR DESCRIPTION
Hi Andrew,

This PR goes with the driver model API you already merged.
It adds model information (nickname, supported transport and connection string) to AddInstrumentDialog:

![ngscopeclient_AYsDHJJlgG](https://github.com/user-attachments/assets/a7a552a8-ba9f-44ff-b5d0-e2e8eecc9817)

For drivers that implement the GetDriverSupportedModels() method, the list of available transports will be limited to supported transports and nickname and connection string will be pre-filled.
For other drivers, the behavior of the AddInstrumentDialog remains unchanged.
If a driver lists more than one model, a model combo is added to the dialog.