### PR TITLE
Fix tooltip behavior on tiling window managers

### DIFF
--- a/src/ngscopeclient/CreateFilterBrowser.cpp
+++ b/src/ngscopeclient/CreateFilterBrowser.cpp
@@ -166,6 +166,11 @@ bool CreateFilterBrowser::DoRender()
 			if(ImGui::IsItemHovered(ImGuiHoveredFlags_ForTooltip) &&
 				!mouseIsDown && !isDragging)
 			{
+				// The tooltip introduced some issues on tiling window managers since it sometimes created
+				// a second OS window when ImGuiConfigFlags_ViewportsEnable was set as a config flag to ImGui.
+				// This forces the tooltip to be a child of the main viewport.
+				ImGui::SetNextWindowViewport(ImGui::GetMainViewport()->ID);
+				// Don't put anything in between since this could lead to the SetNextWindowViewport call affecting other windows.
 				if(ImGui::BeginTooltip())
 				{
 					ImGui::TextUnformatted(it.first.c_str());

--- a/src/ngscopeclient/CreateFilterBrowser.cpp
+++ b/src/ngscopeclient/CreateFilterBrowser.cpp
@@ -168,8 +168,8 @@ bool CreateFilterBrowser::DoRender()
 			{
 				// The tooltip introduced some issues on tiling window managers since it sometimes created
 				// a second OS window when ImGuiConfigFlags_ViewportsEnable was set as a config flag to ImGui.
-				// This forces the tooltip to be a child of the main viewport.
-				ImGui::SetNextWindowViewport(ImGui::GetMainViewport()->ID);
+				// This forces the tooltip to be a child of the viewport of the currently active window.
+				ImGui::SetNextWindowViewport(ImGui::GetWindowViewport()->ID);
 				// Don't put anything in between since this could lead to the SetNextWindowViewport call affecting other windows.
 				if(ImGui::BeginTooltip())
 				{


### PR DESCRIPTION
As discussed in #708 the behavior of the tooltip on tiling window managers is buggy when "Appearance/Windowing/Viewport Mode" is set to "Multi window".  When the tooltip would move outside the main window, the tooltip creats a secondary window, on tiling managers this leads to either a shift in window layouts or the creation of an opaque full container window since the tooltip is not correctly tagged as floating.

The addition from this PR forces the tooltip to be a child of the current windows viewport which fixes this issue by confining the tooltip to the to the confines of the current window.

The bavior was tested on i3wm and it seems to work as intended.