### PR TITLE
Add Flatpak packaging

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -21,10 +21,10 @@ jobs:
 
     - name: Check Out Submodules
       run: |
-        git config submodule.lib.url https://github.com/ngscopeclient/scopehal.git
-        git config submodule.doc.url https://github.com/ngscopeclient/scopehal-docs.git
-        git submodule sync --recursive
-        git submodule update --init --recursive
+        git -C "$GITHUB_WORKSPACE" config submodule.lib.url https://github.com/ngscopeclient/scopehal.git
+        git -C "$GITHUB_WORKSPACE" config submodule.doc.url https://github.com/ngscopeclient/scopehal-docs.git
+        git -C "$GITHUB_WORKSPACE" submodule sync --recursive
+        git -C "$GITHUB_WORKSPACE" submodule update --init --recursive
 
     - name: Build Flatpak bundle
       uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -16,8 +16,15 @@ jobs:
     - name: Check Out Code
       uses: actions/checkout@v6
       with:
-        submodules: recursive
+        submodules: false
         fetch-depth: 0
+
+    - name: Check Out Submodules
+      run: |
+        git config submodule.lib.url https://github.com/ngscopeclient/scopehal.git
+        git config submodule.doc.url https://github.com/ngscopeclient/scopehal-docs.git
+        git submodule sync --recursive
+        git submodule update --init --recursive
 
     - name: Build Flatpak bundle
       uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,0 +1,29 @@
+name: Build-flatpak
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  Flatpak:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
+      options: --privileged
+
+    steps:
+    - name: Check Out Code
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Build Flatpak bundle
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      env:
+        FLATPAK_BUILDER_N_JOBS: "2"
+      with:
+        bundle: ngscopeclient.flatpak
+        manifest-path: packaging/flatpak/org.ngscopeclient.ngscopeclient.yml
+        cache-key: flatpak-builder-${{ github.sha }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,17 +361,21 @@ set(CPACK_STRIP_FILES TRUE)
 
 # Figure out what distro version we're on
 if(LINUX)
-	find_program(LSB_RELEASE_EXEC lsb_release REQUIRED)
-	execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
-		OUTPUT_VARIABLE DISTRO_NAME
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-		COMMAND_ERROR_IS_FATAL ANY)
-	execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs
-		OUTPUT_VARIABLE DISTRO_VER
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-		COMMAND_ERROR_IS_FATAL ANY)
+	find_program(LSB_RELEASE_EXEC lsb_release)
+	if(LSB_RELEASE_EXEC)
+		execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
+			OUTPUT_VARIABLE DISTRO_NAME
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			COMMAND_ERROR_IS_FATAL ANY)
+		execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs
+			OUTPUT_VARIABLE DISTRO_VER
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			COMMAND_ERROR_IS_FATAL ANY)
 
-	message(STATUS "Linux distribution target for packaging: name ${DISTRO_NAME}, version ${DISTRO_VER}")
+		message(STATUS "Linux distribution target for packaging: name ${DISTRO_NAME}, version ${DISTRO_VER}")
+	else()
+		message(STATUS "lsb_release not found; distro-specific package metadata unavailable")
+	endif()
 
 	# Debian specific packaging config
 	set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Andrew Zonenberg <andrew.zonenberg@antikernel.net>")

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,22 @@
+# Flatpak packaging
+
+This directory contains a Flatpak manifest for building ngscopeclient as
+`org.ngscopeclient.ngscopeclient`.
+
+Build locally from the repository root with:
+
+```sh
+flatpak-builder --force-clean --install-deps-from=flathub build-flatpak packaging/flatpak/org.ngscopeclient.ngscopeclient.yml
+```
+
+On memory-constrained builders, add `--jobs=2`.
+
+Create a bundle with:
+
+```sh
+flatpak-builder --repo=flatpak-repo --force-clean --install-deps-from=flathub build-flatpak packaging/flatpak/org.ngscopeclient.ngscopeclient.yml
+flatpak build-bundle flatpak-repo ngscopeclient.flatpak org.ngscopeclient.ngscopeclient
+```
+
+The manifest grants network and device access because ngscopeclient controls
+test instruments over network, USB, serial, and GPU/Vulkan interfaces.

--- a/packaging/flatpak/org.ngscopeclient.ngscopeclient.yml
+++ b/packaging/flatpak/org.ngscopeclient.ngscopeclient.yml
@@ -1,0 +1,126 @@
+app-id: org.ngscopeclient.ngscopeclient
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: ngscopeclient
+rename-desktop-file: ngscopeclient.desktop
+rename-icon: ngscopeclient
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --device=all
+  - --filesystem=xdg-documents:rw
+  - --filesystem=xdg-download:rw
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+modules:
+  - name: yaml-cpp
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DYAML_BUILD_SHARED_LIBS=ON
+      - -DYAML_CPP_BUILD_TESTS=OFF
+      - -DYAML_CPP_BUILD_TOOLS=OFF
+    sources:
+      - type: git
+        url: https://github.com/jbeder/yaml-cpp.git
+        commit: f7320141120f720aecc4c32be25586e7da9eb978
+      - type: patch
+        path: patches/yaml-cpp-gcc15-cstdint.patch
+
+  - name: libsigcplusplus
+    buildsystem: meson
+    config-opts:
+      - -Dbuild-documentation=false
+      - -Dbuild-examples=false
+      - -Dbuild-tests=false
+      - -Dmaintainer-mode=false
+    sources:
+      - type: git
+        url: https://github.com/libsigcplusplus/libsigcplusplus.git
+        commit: eb7db8ef3b5cba44ec4b46d158ec03e2aa3c537a
+
+  - name: hidapi
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DHIDAPI_BUILD_HIDTEST=OFF
+      - -DHIDAPI_WITH_HIDRAW=ON
+      - -DHIDAPI_WITH_LIBUSB=OFF
+    sources:
+      - type: git
+        url: https://github.com/libusb/hidapi.git
+        commit: dbff4ea89f55a572aeb0c53a7b32ea70853ec260
+
+  - name: glfw
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DGLFW_BUILD_DOCS=OFF
+      - -DGLFW_BUILD_EXAMPLES=OFF
+      - -DGLFW_BUILD_TESTS=OFF
+    sources:
+      - type: git
+        url: https://github.com/glfw/glfw.git
+        commit: a74efa0d5628b74adc0426af4c5710e287fa7c2c
+
+  - name: spirv-headers
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://github.com/KhronosGroup/SPIRV-Headers.git
+        commit: 09913f088a1197aba4aefd300a876b2ebbaa3391
+
+  - name: spirv-tools
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSPIRV_SKIP_TESTS=ON
+      - -DSPIRV_WERROR=OFF
+    sources:
+      - type: git
+        url: https://github.com/KhronosGroup/SPIRV-Tools.git
+        commit: f289d047f49fb60488301ec62bafab85573668cc
+      - type: git
+        url: https://github.com/KhronosGroup/SPIRV-Headers.git
+        commit: 09913f088a1197aba4aefd300a876b2ebbaa3391
+        dest: external/spirv-headers
+
+  - name: glslang
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTING=OFF
+      - -DBUILD_EXTERNAL=OFF
+      - -DALLOW_EXTERNAL_SPIRV_TOOLS=ON
+      - -DENABLE_OPT=ON
+    sources:
+      - type: git
+        url: https://github.com/KhronosGroup/glslang.git
+        commit: 7200bc12a8979d13b22cd52de80ffb7d41939615
+
+  - name: ngscopeclient
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DDISABLE_PCH=ON
+      - -DBUILD_TESTING=OFF
+      - -DBUILD_DOCS=OFF
+      - -DBUILD_DEVDOCS=OFF
+      - -DNGSCOPECLIENT_PACKAGE_VERSION=v0.1
+      - -DNGSCOPECLIENT_PACKAGE_VERSION_LONG=v0.1-0
+    sources:
+      - type: dir
+        path: ../..

--- a/packaging/flatpak/patches/yaml-cpp-gcc15-cstdint.patch
+++ b/packaging/flatpak/patches/yaml-cpp-gcc15-cstdint.patch
@@ -1,0 +1,10 @@
+diff --git a/src/emitterutils.cpp b/src/emitterutils.cpp
+index 91408b2..450f7b0 100644
+--- a/src/emitterutils.cpp
++++ b/src/emitterutils.cpp
+@@ -1,4 +1,5 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>
+ #include <sstream>
+ 

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -259,6 +259,8 @@ if(LINUX)
 		DESTINATION share/applications)
 	install(FILES ${CMAKE_SOURCE_DIR}/src/ngscopeclient/ngscopeclient.xml
 		DESTINATION share/mime/packages)
+	install(FILES ${CMAKE_SOURCE_DIR}/src/ngscopeclient/org.ngscopeclient.ngscopeclient.metainfo.xml
+		DESTINATION share/metainfo)
 endif()
 
 if(APPLE)
@@ -357,4 +359,3 @@ if(WIXPATH AND WIN32)
 elseif(WIN32)
 	message("Skipping MSI package build; define WIXPATH to enable")
 endif()
-

--- a/src/ngscopeclient/org.ngscopeclient.ngscopeclient.metainfo.xml
+++ b/src/ngscopeclient/org.ngscopeclient.ngscopeclient.metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.ngscopeclient.ngscopeclient</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+  <name>ngscopeclient</name>
+  <summary>Remote-control and signal-analysis suite for test equipment</summary>
+  <description>
+    <p>
+      ngscopeclient provides cross-platform remote control, waveform analysis,
+      protocol decoding, and visualization for oscilloscopes and other test and
+      measurement instruments.
+    </p>
+  </description>
+  <launchable type="desktop-id">org.ngscopeclient.ngscopeclient.desktop</launchable>
+  <url type="homepage">https://www.ngscopeclient.org/</url>
+  <url type="bugtracker">https://github.com/ngscopeclient/scopehal-apps/issues</url>
+  <developer id="org.ngscopeclient">
+    <name>ngscopeclient.org project</name>
+  </developer>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.1" date="2026-05-12" />
+  </releases>
+</component>


### PR DESCRIPTION
Fixes #987.

## Summary
- Add a Flatpak manifest for org.ngscopeclient.ngscopeclient using the GNOME 50 runtime.
- Add AppStream metadata installation and a GitHub Actions workflow that builds ngscopeclient.flatpak.
- Make lsb_release optional during CMake configure so the Flatpak SDK can build the project.

## Validation
- flatpak-builder-lint manifest packaging/flatpak/org.ngscopeclient.ngscopeclient.yml
- appstreamcli validate --no-net src/ngscopeclient/org.ngscopeclient.ngscopeclient.metainfo.xml
- flatpak-builder --jobs=2 --force-clean --disable-rofiles-fuse --install-deps-from=flathub --repo=.flatpak-build/repo .flatpak-build/build packaging/flatpak/org.ngscopeclient.ngscopeclient.yml
- flatpak build-bundle .flatpak-build/repo .flatpak-build/ngscopeclient.flatpak org.ngscopeclient.ngscopeclient
