### PR TITLE
Properly Visualize the Filter Messages in the UI

### DIFF
--- a/src/ngscopeclient/FilterGraphEditor.cpp
+++ b/src/ngscopeclient/FilterGraphEditor.cpp
@@ -2142,14 +2142,14 @@ void FilterGraphEditor::DoNodeForChannel(
 
 	auto& prefs = m_session->GetPreferences();
 	ImU32 messageColors[] = {
-		0,
-		0,
+		prefs.GetColor("Appearance.Filter Graph.error_outline_color"), // 0 zero in enum is not set, therefore placeholder
+		prefs.GetColor("Appearance.Filter Graph.error_outline_color"), // Also no fatal error should be ever sent, but better than crash
 		prefs.GetColor("Appearance.Filter Graph.error_outline_color"),
 		prefs.GetColor("Appearance.Filter Graph.warning_outline_color"),
 		prefs.GetColor("Appearance.Filter Graph.notice_outline_color"),
 		prefs.GetColor("Appearance.Filter Graph.verbose_outline_color"),
 		prefs.GetColor("Appearance.Filter Graph.debug_outline_color"),
-		0
+		prefs.GetColor("Appearance.Filter Graph.debug_outline_color"), // We don't need crash, so placeholder
 	};
 
 	//Get some configuration / style settings

--- a/src/ngscopeclient/FilterGraphEditor.cpp
+++ b/src/ngscopeclient/FilterGraphEditor.cpp
@@ -2141,7 +2141,16 @@ void FilterGraphEditor::DoNodeForChannel(
 		displaycolor = "#808080";
 
 	auto& prefs = m_session->GetPreferences();
-	auto errorColor = prefs.GetColor("Appearance.Filter Graph.error_outline_color");
+	ImU32 messageColors[] = {
+		0,
+		0,
+		prefs.GetColor("Appearance.Filter Graph.error_outline_color"),
+		prefs.GetColor("Appearance.Filter Graph.warning_outline_color"),
+		prefs.GetColor("Appearance.Filter Graph.notice_outline_color"),
+		prefs.GetColor("Appearance.Filter Graph.verbose_outline_color"),
+		prefs.GetColor("Appearance.Filter Graph.debug_outline_color"),
+		0
+	};
 
 	//Get some configuration / style settings
 	auto color = ColorFromString(displaycolor);
@@ -2414,7 +2423,8 @@ void FilterGraphEditor::DoNodeForChannel(
 
 		//Draw outline rectangle around the entire filter
 		auto errorOutlineThickness = 0.4 * ImGui::GetFontSize();
-		bgList->AddRect(pos, pos+size, errorColor, rounding, ImDrawFlags_RoundCornersAll, errorOutlineThickness);
+		auto outlineColor = messageColors[static_cast<int>(msg->GetSeverity())];
+		bgList->AddRect(pos, pos+size, outlineColor, rounding, ImDrawFlags_RoundCornersAll, errorOutlineThickness);
 	}
 
 	ImGui::PopFont(); // headerfont

--- a/src/ngscopeclient/FilterGraphEditor.cpp
+++ b/src/ngscopeclient/FilterGraphEditor.cpp
@@ -2371,9 +2371,11 @@ void FilterGraphEditor::DoNodeForChannel(
 	}
 
 	//Display errors
-	if(channel->HasErrors())
+	if(channel->HasMessages())
 	{
-		auto errorText = channel->GetErrorTitle();
+		// We only display the most severe message for now
+		auto msg = channel->GetMostSevereMessage();
+		auto errorText = msg->GetTitle();
 		auto errorSize = ImGui::CalcTextSize(errorText.c_str());
 
 		auto textColor = ImGui::GetColorU32(ImGui::GetStyleColorVec4(ImGuiCol_Text));
@@ -2398,7 +2400,7 @@ void FilterGraphEditor::DoNodeForChannel(
 		if( (mousepos.x > rectStart.x) && (mousepos.y > rectStart.y) &&
 			(mousepos.x < rectEnd.x) && (mousepos.y < rectEnd.y) )
 		{
-			auto log = Trim(channel->GetErrorLog());
+			auto log = Trim(msg->GetMessage());
 
 			ax::NodeEditor::Suspend();
 				MainWindow::SetTooltipPosition();

--- a/src/ngscopeclient/FilterGraphErrorWindow.cpp
+++ b/src/ngscopeclient/FilterGraphErrorWindow.cpp
@@ -59,15 +59,15 @@ bool FilterGraphErrorWindow::Render()
 {
 	//Refresh list of errors
 	auto& nodes = Filter::GetAllInstances();
-	m_nodesWithErrors.clear();
+	m_nodesWithMessages.clear();
 	for(auto node : nodes)
 	{
-		if(node->HasErrors())
-			m_nodesWithErrors.emplace(node);
+		if(node->HasMessages())
+			m_nodesWithMessages.emplace(node);
 	}
 
 	//Show error window on first run, or if we have errors
-	if(!m_nodesWithErrors.empty())
+	if(!m_nodesWithMessages.empty())
 		m_open = true;
 	else if(m_firstRun)
 	{
@@ -97,27 +97,30 @@ bool FilterGraphErrorWindow::DoRender()
 		ImGuiTableFlags_SizingFixedFit;
 
 	auto width = ImGui::GetFontSize();
-	if(ImGui::BeginTable("table", 2, flags))
+	if(ImGui::BeginTable("table", 3, flags))
 	{
 		ImGui::TableSetupScrollFreeze(0, 1); //Header row does not scroll
 
+		ImGui::TableSetupColumn("Severity", ImGuiTableColumnFlags_WidthFixed, 6*width);
 		ImGui::TableSetupColumn("Channel", ImGuiTableColumnFlags_WidthFixed, 12*width);
 		ImGui::TableSetupColumn("Error", ImGuiTableColumnFlags_WidthStretch, 0);
 		ImGui::TableHeadersRow();
 
-		for(auto f : m_nodesWithErrors)
+		for(auto f : m_nodesWithMessages)
 		{
-			auto messages = explode(f->GetErrorLog(), '\n');
-			for(auto& m : messages)
+			for(auto& m : f->GetMessages())
 			{
-				//remove bullet and space
-				string s = m.substr(m.find(' ') + 1);
-
+				// TODO: Combine this with logging library and merge the enum-Str mapping
+				const char* severity_str[] = {
+					"NOTHING", "FATAL", "ERROR", "WARNING", "NOTICE", "VERBOSE", "DEBUG", "TRACE"
+				};
 				ImGui::TableNextRow(ImGuiTableRowFlags_None);
 				ImGui::TableSetColumnIndex(0);
-				ImGui::TextUnformatted(f->GetDisplayName().c_str());
+				ImGui::TextUnformatted(severity_str[static_cast<int>(m.GetSeverity())]);
 				ImGui::TableSetColumnIndex(1);
-				ImGui::TextUnformatted(s.c_str());
+				ImGui::TextUnformatted(f->GetDisplayName().c_str());
+				ImGui::TableSetColumnIndex(2);
+				ImGui::TextUnformatted(m.GetMessage().c_str());
 			}
 		}
 

--- a/src/ngscopeclient/FilterGraphErrorWindow.h
+++ b/src/ngscopeclient/FilterGraphErrorWindow.h
@@ -47,7 +47,7 @@ public:
 	virtual bool DoRender();
 
 protected:
-	std::set<InstrumentChannel*> m_nodesWithErrors;
+	std::set<InstrumentChannel*> m_nodesWithMessages;
 	bool m_firstRun;
 };
 

--- a/src/ngscopeclient/PreferenceSchema.cpp
+++ b/src/ngscopeclient/PreferenceSchema.cpp
@@ -162,10 +162,6 @@ void PreferenceManager::InitializeDefaults()
 				.Label("Info bubble color")
 				.Description("Color for information bubbles displayed above graph nodes"));
 			graph.AddPreference(
-				Preference::Color("error_outline_color", ColorFromString("#ff0000"))
-				.Label("Error outline color")
-				.Description("Color for outlining graph nodes with errors"));
-			graph.AddPreference(
 				Preference::Font("icon_caption_font", FontDescription(FindDataFile("fonts/DejaVuSans.ttf"), 13))
 				.Label("Icon font")
 				.Description("Font for icon captions"));
@@ -173,6 +169,27 @@ void PreferenceManager::InitializeDefaults()
 				Preference::Color("icon_caption_color", ColorFromString("#ffffff"))
 				.Label("Icon color")
 				.Description("Color for icon captions"));
+
+			graph.AddPreference(
+				Preference::Color("error_outline_color", ColorFromString("#ff0000"))
+				.Label("Error outline color")
+				.Description("Color for outlining graph nodes with errors"));
+			graph.AddPreference(
+				Preference::Color("warning_outline_color", ColorFromString("#ffff00"))
+				.Label("Warning outline color")
+				.Description("Color for outlining graph nodes with warnings"));
+			graph.AddPreference(
+				Preference::Color("notice_outline_color", ColorFromString("#00ff00"))
+				.Label("Notice outline color")
+				.Description("Color for outlining graph nodes with notice messages"));
+			graph.AddPreference(
+					Preference::Color("verbose_outline_color", ColorFromString("#a0a0ff"))
+					.Label("Verbose outline color")
+					.Description("Color for outlining graph nodes with verbose messages"));
+			graph.AddPreference(
+					Preference::Color("debug_outline_color", ColorFromString("#a0a0a0"))
+					.Label("Debug outline color")
+					.Description("Color for outlining graph nodes with debug messages"));
 
 		auto& ahelp = appearance.AddCategory("Help");
 			ahelp.AddPreference(


### PR DESCRIPTION
This is the UI-Adjustments for the new Message system for filters in https://github.com/ngscopeclient/scopehal/pull/1093
The Error Tab now properly lists each error with their severity and adjusts the filters border color in the graph view to each severity.
For that respective settings entries were created.

The scopehal PR mentioned is required for this.