### PR TITLE
FontManager: Don't warn of not found font if no filename was given.

### DIFF
--- a/src/ngscopeclient/FontManager.cpp
+++ b/src/ngscopeclient/FontManager.cpp
@@ -95,11 +95,14 @@ bool FontManager::UpdateFonts(PreferenceCategory& root)
 			fclose(fp);
 		else
 		{
-			LogWarning(
-				"Could not find font file \"%s\" requested in preferences database. "
-				"Using default font \"%s\" instead\n",
-				fname.c_str(),
-				defaultFontPath.c_str());
+			// No need to warn the user if nothing is specified
+			if(fname.size() != 0) {
+				LogWarning(
+					"Could not find font file \"%s\" requested in preferences database. "
+					"Using default font \"%s\" instead\n",
+					fname.c_str(),
+					defaultFontPath.c_str());
+			}
 			fname = defaultFontPath;
 		}
 


### PR DESCRIPTION
In some configurations the default font is simply specified by leaving the config field empty.
The current behavior is warning about not having font file "" and informing of the default font being used.
Imo the only usecase where this warning is useful if a fontfile was actually set.
To prevent overexaustion of warnings not related this change only prints out a warning if the font to load is actually not empty.